### PR TITLE
netns ls error

### DIFF
--- a/network/list.go
+++ b/network/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"net"
 
 	"github.com/boltdb/bolt"
 	"github.com/vishvananda/netns"
@@ -18,7 +19,7 @@ func (c *Client) List() ([]Network, error) {
 		return nil, err
 	}
 	defer c.db.Close()
-	
+
 	if c.db == nil {
 		return nil, errors.New("no networks found")
 	}
@@ -40,6 +41,9 @@ func (c *Client) List() ([]Network, error) {
 			n := Network{
 				IP: k,
 			}
+
+			//We need to parse, or the pointer to k will be lost
+			n.IP = net.ParseIP(n.IP.String())
 
 			// Get the pid.
 			n.PID, err = strconv.Atoi(string(v))

--- a/network/list.go
+++ b/network/list.go
@@ -13,14 +13,15 @@ import (
 // List returns the ip addresses being used from the database for the networks
 // with the specified bridge name.
 func (c *Client) List() ([]Network, error) {
-	if c.db == nil {
-		return nil, errors.New("no networks found")
-	}
 	// Open the database.
 	if err := c.openDB(true); err != nil {
 		return nil, err
 	}
 	defer c.db.Close()
+	
+	if c.db == nil {
+		return nil, errors.New("no networks found")
+	}
 
 	var (
 		networks = []Network{}


### PR DESCRIPTION
Before the commit https://github.com/genuinetools/netns/commit/dc5a5f61976940ba2fdcf77546f4f11e3a9cc11d :

**netns ls command always return:**
```
no networks found
```
Because without openDB, the db field is always nil.

**After fix this error, there'll be new errors:**
```
unexpected fault address 0x7efdcdab7070
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7efdcdab7070 pc=0x4f3ee8]

goroutine 1 [running]:
runtime.throw(0x6ddfa4, 0x5)
	/opt/go/src/runtime/panic.go:616 +0x81 fp=0xc420053ab8 sp=0xc420053a98 pc=0x42b061
runtime.sigpanic()
	/opt/go/src/runtime/signal_unix.go:395 +0x211 fp=0xc420053b08 sp=0xc420053ab8 pc=0x43f611
net.IP.String(0x7efdcdab7070, 0x4, 0x4, 0x1, 0x1)
	/opt/go/src/net/ip.go:278 +0x3c8 fp=0xc420053c40 sp=0xc420053b08 pc=0x4f3ee8
main.(*listCommand).Run(0x87d718, 0x712640, 0xc42007eae0, 0xc420090000, 0x0, 0x0, 0x3, 0x6)
	/root/gocode/src/github.com/genuinetools/netns/list.go:33 +0x1ba fp=0xc420053dc0 sp=0xc420053c40 pc=0x644c4a
github.com/genuinetools/netns/vendor/github.com/genuinetools/pkg/cli.(*Program).run(0xc4200c4000, 0x712640, 0xc42007eae0, 0xc420090000, 0x2, 0x2, 0x712640, 0xc42007eae0, 0x4120e8)
	/root/gocode/src/github.com/genuinetools/netns/vendor/github.com/genuinetools/pkg/cli/cli.go:173 +0x365 fp=0xc420053e78 sp=0xc420053dc0 pc=0x642715
github.com/genuinetools/netns/vendor/github.com/genuinetools/pkg/cli.(*Program).Run(0xc4200c4000)
	/root/gocode/src/github.com/genuinetools/netns/vendor/github.com/genuinetools/pkg/cli/cli.go:88 +0x170 fp=0xc420053f18 sp=0xc420053e78 pc=0x642240
main.main()
	/root/gocode/src/github.com/genuinetools/netns/main.go:126 +0x4a1 fp=0xc420053f88 sp=0xc420053f18 pc=0x645311
runtime.main()
	/opt/go/src/runtime/proc.go:198 +0x212 fp=0xc420053fe0 sp=0xc420053f88 pc=0x42c8d2
runtime.goexit()
	/opt/go/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc420053fe8 sp=0xc420053fe0 pc=0x456761
```
Because n.IP address is lost. The commit https://github.com/genuinetools/netns/commit/843fda5ac35383f580a7637972325539a274e673 is aim to fix this error.

**After fix:**
netns ls
```
IP                  LOCAL VETH          PID                 STATUS              NS FD
172.19.0.2          netnsv0-1116        1116                running             5
```