### PR TITLE
Add static IP command line switch

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ const (
 )
 
 var (
-	arg    string
-	ipfile string
+	arg      string
+	ipfile   string
+	staticip string
 
 	netOpt network.Opt
 	brOpt  bridge.Opt
@@ -86,6 +87,7 @@ func main() {
 	p.FlagSet.IntVar(&brOpt.MTU, "mtu", bridge.DefaultMTU, "mtu for bridge")
 
 	p.FlagSet.BoolVar(&debug, "d", false, "enable debug logging")
+	p.FlagSet.StringVar(&staticip, "static-ip", "", "Enable static IP Address")
 
 	// Set the before function.
 	p.Before = func(ctx context.Context) error {
@@ -109,7 +111,7 @@ func main() {
 			return err
 		}
 
-		ip, err := client.Create(hook, brOpt)
+		ip, err := client.Create(hook, brOpt, staticip)
 		if err != nil {
 			return err
 		}

--- a/network/create.go
+++ b/network/create.go
@@ -16,7 +16,8 @@ import (
 
 // Create returns a container IP that was created with the given bridge name,
 // the settings from the HookState passed, and the bridge options.
-func (c *Client) Create(hook configs.HookState, brOpt bridge.Opt) (net.IP, error) {
+func (c *Client) Create(hook configs.HookState, brOpt bridge.Opt, staticip string) (net.IP, error) {
+	var nsip net.IP
 	// Open the database.
 	if err := c.openDB(false); err != nil {
 		return nil, err
@@ -79,7 +80,12 @@ func (c *Client) Create(hook configs.HookState, brOpt bridge.Opt) (net.IP, error
 		return nil, err
 	}
 
-	nsip, err := c.AllocateIP(hook.Pid)
+	if staticip != "" {
+		nsip = net.ParseIP(staticip)
+	} else {
+		nsip, err = c.AllocateIP(hook.Pid)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("allocating ip address failed: %v", err)
 	}

--- a/network/create_test.go
+++ b/network/create_test.go
@@ -32,7 +32,7 @@ func TestCreateNetwork(t *testing.T) {
 	}, bridge.Opt{
 		IPAddr: defaultBridgeIP,
 		Name:   defaultBridgeName,
-	})
+	}, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
There are use cases in which a container needs a persistent static IP.
This patch adds a switch to set a static IP for a container.

Eg.

"hooks": {
                "prestart": [
                	{
                        	"path": "/home/example/go/src/github.com/genuinetools/netns/netns",
                        	"args": ["netns", "--static-ip", "172.19.0.2"]
                	}
                ]
        }

closes #11