### PR TITLE
Match bridge MTU when creating veth pair

### DIFF
--- a/network/create.go
+++ b/network/create.go
@@ -184,6 +184,7 @@ func (c *Client) vethPair(pid int, bridgeName string) (*netlink.Veth, error) {
 
 	la := netlink.NewLinkAttrs()
 	la.Name = fmt.Sprintf("%s-%d", c.opt.PortPrefix, pid)
+	la.MTU = br.Attrs().MTU
 	la.MasterIndex = br.Attrs().Index
 
 	return &netlink.Veth{


### PR DESCRIPTION
This bug resulted in mtu mismatch between the bridge
and veth pair when a custom MTU was provided.